### PR TITLE
configure.py reads from stdin if no command line arg provided.

### DIFF
--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -1,11 +1,14 @@
-import json
+import json, sys
 from os.path import isfile
+
 
 def load_config(file_name):
     if isfile(file_name):
         with open(file_name) as fh:
             return json.load(fh)
-    else:
+    elif file_name == '-':
+        return json.loads(sys.stdin.read())
+    else :
         return dict()
 
 
@@ -19,7 +22,9 @@ def get_value(value):
 if __name__ == '__main__':
     config = load_config('static.json')
 
-    for env_file, entry in load_config('config.json').items():
+    filename = sys.argv[1] if len(sys.argv) > 1 else '-'
+
+    for env_file, entry in load_config(filename).items():
         if env_file in config:
             config[env_file].update(entry)
         else:

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -1,5 +1,15 @@
-import json, sys
+#! /usr/bin/env python3
+
+import json, sys, argparse
 from os.path import isfile
+
+# ******************************************************************************
+parser = argparse.ArgumentParser(description='Reads config.json and writes out docker-environment files.')
+
+parser.add_argument('file', nargs='?', help='optional input file, if omitted, read from stdin', default='-')
+parser.add_argument('-v', '--verbose', action='store_true', help="be verbose")
+args = parser.parse_args()
+# ******************************************************************************
 
 
 def load_config(file_name):
@@ -22,7 +32,12 @@ def get_value(value):
 if __name__ == '__main__':
     config = load_config('static.json')
 
-    filename = sys.argv[1] if len(sys.argv) > 1 else '-'
+    # prevents script from trying to read interactively from tty, only "proper" pipe allowed
+    if (args.file == '-' and sys.stdin.isatty()):
+        print ("Won't read input from tty (please use -h for help)", file=sys.stderr)
+        exit(1)
+    else:
+        filename = args.file
 
     for env_file, entry in load_config(filename).items():
         if env_file in config:


### PR DESCRIPTION
    * changed configure.py to the following additional behaviour: if no command
      line argument given, read from stdin, otherwise retain old behaviour
      in treating arg as filename.