### PR TITLE
Fix "Won't read input from tty"

### DIFF
--- a/docs/pages/core/keycloak.md
+++ b/docs/pages/core/keycloak.md
@@ -80,7 +80,7 @@ script within a docker container
 
 ```bash
 # create environment files from config
-python ../scripts/configure.py
+python ../scripts/configure.py config.json
 
 # start the keycloak service
 docker-compose up -d


### PR DESCRIPTION
The python script expects either a pipe or a .json config

Step will fail if just copy pasted from docs

Fixed by adding config.json to the call