### PR TITLE
Fixed app build context for submodule usage

### DIFF
--- a/wg-mesh/compose.yml
+++ b/wg-mesh/compose.yml
@@ -79,7 +79,7 @@ services:
     restart: unless-stopped
 
   app:
-    build: ../docker-images/app
+    build: ../../docker-images/app
     container_name: app
     networks:
       wgnet:


### PR DESCRIPTION
Fixed the path for the `app` debugging/testing container so that it works when repo is used as submodule.