### PR TITLE
Move the default rocket address to Dockerfile

### DIFF
--- a/wg-mesh/compose.yml
+++ b/wg-mesh/compose.yml
@@ -24,8 +24,6 @@ services:
       - RUST_BACKTRACE=full
       - WG_CONTAINER=${SUBNET_PREFIX}ff
       - WG_ENDPOINT=${WG_ENDPOINT}
-      # Let Rocket listen to all addresses
-      - ROCKET_ADDRESS="unix:/pmd_config/daemon.sock"
     labels:
       # Not to be accessed from other mesh participants
       de.material-digital.mesh-connectivity: private


### PR DESCRIPTION
Realized that we can move the `ROCKET_ADDRESS` default value to Dockerfile, i.e., to the container build. This is more robust as it can still be overridden but doesn't require to touch `compose.yml` on default changes.